### PR TITLE
Adding pipeline steps and logic for human only variant calling

### DIFF
--- a/discovery_variables.yml
+++ b/discovery_variables.yml
@@ -16,6 +16,6 @@ trimgalore: /ihome/gway/.conda/envs/pdx-exomeseq/bin/trim_galore
 bwa: /ihome/gway/.conda/envs/pdx-exomeseq/bin/bwa
 samtools: /ihome/gway/.conda/envs/pdx-exomeseq/bin/samtools
 picard: /ihome/gway/.conda/envs/pdx-exomeseq/bin/picard
-gatk: /ihome/gway/.conda/envs/pdx-exomeseq/bin/gatk
+gatk: /ihome/gway/.conda/envs/pdx-exomeseq/bin/gatk3
 disambiguate: /ihome/gway/.conda/envs/pdx-exomeseq/bin/ngs_disambiguate
 mosdepth: /ihome/gway/.conda/envs/pdx-exomeseq/bin/mosdepth

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - r::r-dplyr=0.7.0
 - r::r-readr=1.1.1
 - r::r-gridextra=2.2.1
+- conda-forge::python=3.5
 - conda-forge::r-venndiagram=1.6.18
 - conda-forge::pandas=0.21.0
 - conda-forge::numpy=1.13.3

--- a/pdx_exomeseq.py
+++ b/pdx_exomeseq.py
@@ -28,7 +28,8 @@ E.g.
             --output_directory 'processed/bam' \
             --walltime '06:00:00' \
             --nodes 2 \
-            --cores 12
+            --cores 12 \
+            --humanonly
 
 The specific pipeline using this script is given in `wes_pipeline.sh`
 """
@@ -278,4 +279,3 @@ if __name__ == '__main__':
         schedule_id = '{}_{}'.format(sample_id, command)
         arguments.schedule_job(command=com, name=schedule_id, python=python,
                                nodes=nodes, cores=cores, walltime=walltime)
-

--- a/pdx_exomeseq.py
+++ b/pdx_exomeseq.py
@@ -167,8 +167,7 @@ if command == 'samtools':
 
         elif sub_command == 'fixmate':
             samtools_com = [samtools, 'fixmate',
-                            os.path.join('processed', 'bam_disambiguate',
-                                         sample_id),
+                            os.path.join(input_dir, sample_id),
                             sample_sorted_fixmate_bam]
 
         elif sub_command == 'sort_position':

--- a/pdx_exomeseq.py
+++ b/pdx_exomeseq.py
@@ -42,7 +42,6 @@ import util.arguments as arguments
 # Load command arguments
 args = arguments.get_args()
 command = args.which
-
 genome = args.genome
 input_dir = args.input_directory
 output_dir = args.output_directory
@@ -172,18 +171,16 @@ if command == 'samtools':
 
         elif sub_command == 'sort_position':
             samtools_com = [samtools, 'sort',
-                            os.path.join('processed', 'bam_fixmate',
-                                         sample_id),
+                            os.path.join(input_dir, sample_id),
                             sample_sorted_position_bam]
 
         elif sub_command == 'rmdup':
             samtools_com = [samtools, 'rmdup',
-                            os.path.join('processed', 'bam_sort_position',
-                                         sample_id),
+                            os.path.join(input_dir, sample_id),
                             sample_markdup_bam]
 
         elif sub_command == 'index_bam':
-            sample_file = os.path.join('processed', 'bam_rmdup', sample_id)
+            sample_file = os.path.join(input_dir, sample_id)
             samtools_com = [samtools, 'index', sample_file, sample_markdup_bai]
 
         elif sub_command == 'index_bam_gatk':

--- a/pdx_exomeseq.py
+++ b/pdx_exomeseq.py
@@ -79,6 +79,10 @@ gatk = config['gatk']
 disambiguate = config['disambiguate']
 mosdepth = config['mosdepth']
 
+# Ensure the output directory exists
+if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
+
 ############################
 # Generate the commands
 ############################

--- a/setup_environment.sh
+++ b/setup_environment.sh
@@ -16,7 +16,7 @@ source activate pdx-exomeseq
 # Step 3: Register GATK
 # MANUAL STEP: Download Gatk3.8-0 and move to `modules`
 # Download from: https://software.broadinstitute.org/gatk/download/
-gatk-register modules/GenomeAnalysisTK-3.8-0.tar.bz2
+gatk3-register modules/GenomeAnalysisTK-3.8-0.tar.bz2
 
 # NOTE: Once this script is run once, to recreate the computational environment, simply run:
 # source activate pdx-exomeseq

--- a/util/arguments.py
+++ b/util/arguments.py
@@ -31,6 +31,8 @@ def get_args():
                         help='Configuration variables for input')
     parser.add_argument('-g', '--genome', default='hg',
                         help='name of the reference genome')
+    parser.add_argument('-u', '--humanonly', action='store_true',
+                        help='whether or not to send through human samples')
 
     # Create subcommands for specific pipeline functionality
     parser_fastqc = subparsers.add_parser('fastqc', parents=[parser])
@@ -83,6 +85,14 @@ def schedule_job(command, name, python, nodes=1, cores=4, walltime='04:00:00'):
     return subprocess.call(output_com)
 
 
+def get_human_only(all_files):
+    human_samples = ['004-M', '005-M']
+    output_files = [x for x in all_files if
+                    any(y for y in human_samples if y in x)]
+
+    return output_files
+
+
 def get_fastqc(args):
     wes_files = []
     for path, subdirs, files in os.walk(args.input_directory):
@@ -90,6 +100,10 @@ def get_fastqc(args):
             if re.match(r'(fasta|fq|fastq)\.gz$', name):
                 full_name = os.path.join(path, name)
                 wes_files.append(full_name)
+
+    if args.humanonly:
+        wes_files = get_human_only(wes_files)
+
     return wes_files
 
 
@@ -106,6 +120,10 @@ def get_trimgalore(args):
             read_1 = name
             read_2 = name.replace('_R1_', '_R2_')
             paired_reads.append([read_1, read_2])
+
+    if args.humanonly:
+        paired_reads = get_human_only(paired_reads)
+
     return paired_reads
 
 
@@ -123,6 +141,10 @@ def get_bwa(args):
             read_2 = name.replace('_R1_', '_R2_')
             read_2 = read_2.replace('val_1', 'val_2')
             paired_reads.append([read_1, read_2])
+
+    if args.humanonly:
+        paired_reads = get_human_only(paired_reads)
+
     return paired_reads
 
 
@@ -134,6 +156,10 @@ def get_samtools(args):
         for name in files:
             if (any([x in name for x in check_suffix])) and ('.bai' not in name):
                 sam_files.append(name)
+
+    if args.humanonly:
+        sam_files = get_human_only(sam_files)
+
     return sam_files
 
 
@@ -143,6 +169,10 @@ def get_disambiguate(args):
         for name in files:
             sample_id = name.split('.')[0]  # This extracts the sample ID
             sample_files.append(sample_id)
+
+    if args.humanonly:
+        sample_files = get_human_only(sample_files)
+
     return sample_files
 
 
@@ -153,6 +183,10 @@ def get_variant(args):
         for name in files:
             if (any([x in name for x in check_suffix])) and ('.bai' not in name):
                 bam_files.append(name)
+
+    if args.humanonly:
+        bam_files = get_human_only(bam_files)
+
     return bam_files
 
 
@@ -162,4 +196,8 @@ def get_mosdepth(args):
         for name in files:
             if '.bai' not in name:
                 bam_files.append(name)
+
+    if args.humanonly:
+        bam_files = get_human_only(bam_files)
+
     return bam_files

--- a/util/arguments.py
+++ b/util/arguments.py
@@ -86,7 +86,7 @@ def schedule_job(command, name, python, nodes=1, cores=4, walltime='04:00:00'):
 
 
 def get_human_only(all_files):
-    human_samples = ['004-M', '005-M']
+    human_samples = ['004-primary', '005-primary']
     output_files = [x for x in all_files if
                     any(y for y in human_samples if y in x)]
 

--- a/util/arguments.py
+++ b/util/arguments.py
@@ -31,7 +31,7 @@ def get_args():
                         help='Configuration variables for input')
     parser.add_argument('-g', '--genome', default='hg',
                         help='name of the reference genome')
-    parser.add_argument('-u', '--humanonly', action='store_true',
+    parser.add_argument('-m', '--humanonly', action='store_true',
                         help='whether or not to send through human samples')
 
     # Create subcommands for specific pipeline functionality

--- a/wes_pipeline.sh
+++ b/wes_pipeline.sh
@@ -70,7 +70,7 @@ python pdx_exomeseq.py disambiguate \
         --walltime '06:00:00' --nodes 2 --cores 8
 
 ###################
-# STEP 4 - Data Conversion and Processing
+# STEP 4A - Data Conversion and Processing (after disambiguation)
 ###################
 # Prep for duplicate removal by cleaning up readpair tags
 python pdx_exomeseq.py samtools --sub_command 'fixmate' \
@@ -100,6 +100,44 @@ python pdx_exomeseq.py samtools --sub_command 'index_bam' \
 python pdx_exomeseq.py variant --sub_command 'add_read_groups' \
         --input_directory 'processed/bam_rmdup' \
         --output_directory 'processed/gatk_bam' \
+        --walltime '03:00:00' --nodes 1 --cores 8
+
+###################
+# STEP 4B - Data Conversion and Processing (human only for 004-M and 005-M)
+###################
+# Prep for duplicate removal by cleaning up readpair tags
+python pdx_exomeseq.py samtools --sub_command 'fixmate' \
+        --human_only \
+        --input_directory 'processed/bam' \
+        --output_directory 'processed/bam_fixmate_humanonly' \
+        --walltime '02:30:00' --nodes 2 --cores 4
+
+# Prep for duplicate removal by sorting tagged bam files by position
+python pdx_exomeseq.py samtools --sub_command 'sort_position' \
+        --human_only \
+        --input_directory 'processed/bam_fixmate_humanonly' \
+        --output_directory 'processed/bam_sort_position_humanonly' \
+        --walltime '02:00:00' --nodes 2 --cores 8
+
+# Remove duplicate reads
+python pdx_exomeseq.py samtools --sub_command 'rmdup' \
+       --human_only \
+       --input_directory 'processed/bam_sort_position_humanonly' \
+       --output_directory 'processed/bam_rmdup_humanonly' \
+       --walltime '03:30:00' --nodes 1 --cores 4
+
+# Create BAM index for duplicate removal
+python pdx_exomeseq.py samtools --sub_command 'index_bam' \
+        --human_only \
+        --input_directory 'processed/bam_rmdup_humanonly' \
+        --output_directory 'processed/bam_rmdup_humanonly' \
+        --walltime '03:30:00' --nodes 1 --cores 4
+
+# Assign read groups
+python pdx_exomeseq.py variant --sub_command 'add_read_groups' \
+        --human_only \
+        --input_directory 'processed/bam_rmdup_humanonly' \
+        --output_directory 'processed/gatk_bam_humanonly' \
         --walltime '03:00:00' --nodes 1 --cores 8
 
 ###################


### PR DESCRIPTION
refs #67 

This PR stores the logic and infrastructure to run the human tissue samples through a human-only WES pipeline. Previously, all samples (including all patient derived xenografts) are run through the same pipeline, which aligns to both human and mouse, and then performs a disambiguation step.

Our collaborators were concerned with false positive variants creeping through into the human samples that failed to be filtered.